### PR TITLE
Implements plus_one() and minus_one() in an optimal manner

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -268,6 +268,26 @@ mod tests {
                     }
 
                     #[test]
+                    fn plus_one_is_correct() {
+                        for i in 0..10 {
+                            let value = VALUES[$d][i] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
+                            let value_plus_one = VALUES[$d][i + 1] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
+                            assert_eq!(DilatedInt::<Expand<$t, $d>>(value).plus_one().0, value_plus_one);
+                        }
+                        assert_eq!(DilatedInt::<Expand<$t, $d>>(Expand::<$t, $d>::DILATED_MAX).plus_one().0, 0);
+                    }
+
+                    #[test]
+                    fn minus_one_is_correct() {
+                        for i in 10..0 {
+                            let value = VALUES[$d][i] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
+                            let value_minus_one = VALUES[$d][i - 1] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
+                            assert_eq!(DilatedInt::<Expand<$t, $d>>(value).minus_one().0, value_minus_one);
+                        }
+                        assert_eq!(DilatedInt::<Expand<$t, $d>>(0).minus_one().0, Expand::<$t, $d>::DILATED_MAX);
+                    }
+
+                    #[test]
                     fn dilate_is_correct() {
                         // To create many more valid test cases, we doubly iterate all of them and xor the values
                         for (undilated_a, dilated_a) in DILATION_TEST_CASES[$d].iter() {

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -279,6 +279,26 @@ mod tests {
                         assert_eq!(Fixed::<$t, $d>::DILATED_MAX, TestData::<Fixed<$t, $d>>::dilated_max());
                     }
 
+                    #[test]
+                    fn plus_one_is_correct() {
+                        for i in 0..10 {
+                            let value = VALUES[$d][i] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
+                            let value_plus_one = VALUES[$d][i + 1] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
+                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(value).plus_one().0, value_plus_one);
+                        }
+                        assert_eq!(DilatedInt::<Fixed<$t, $d>>(Fixed::<$t, $d>::DILATED_MAX).plus_one().0, 0);
+                    }
+
+                    #[test]
+                    fn minus_one_is_correct() {
+                        for i in 10..0 {
+                            let value = VALUES[$d][i] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
+                            let value_minus_one = VALUES[$d][i - 1] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
+                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(value).minus_one().0, value_minus_one);
+                        }
+                        assert_eq!(DilatedInt::<Fixed<$t, $d>>(0).minus_one().0, Fixed::<$t, $d>::DILATED_MAX);
+                    }
+
                     // Unique to Fixed dilations
                     #[test]
                     #[should_panic(expected = "Attempting to dilate a value exceeds maximum (See DilationMethod::UNDILATED_MAX)")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,6 +324,37 @@ pub trait DilationMethod: Sized {
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DilatedInt<A>(pub A::Dilated) where A: DilationMethod;
 
+impl<A> DilatedInt<A>
+where
+    A: DilationMethod
+{
+    /// Adds the value 1 to the dilated int and returns the result
+    /// 
+    /// This method is slightly more optimal than adding 1 via the '+' operator
+    /// 
+    /// This method wraps the output value between 0 and [DILATED_MAX](DilationMethod::DILATED_MAX) (inclusive)
+    #[inline]
+    pub fn plus_one(&self) -> Self
+    where
+        A::Dilated: BitAnd<Output = A::Dilated>,
+        Wrapping<A::Dilated>: Sub<Output = Wrapping<A::Dilated>>
+    {
+        Self((Wrapping(self.0) - Wrapping(A::DILATED_MAX)).0 & A::DILATED_MAX)
+    }
+
+    /// Subtracts the value 1 from the dilated int and returns the result
+    /// 
+    /// This method wraps the output value between 0 and [DILATED_MAX](DilationMethod::DILATED_MAX) (inclusive)
+    #[inline]
+    pub fn minus_one(&self) -> Self
+    where
+        A::Dilated: BitAnd<Output = A::Dilated>,
+        Wrapping<A::Dilated>: Add<Output = Wrapping<A::Dilated>>
+    {
+        Self((Wrapping(self.0) + Wrapping(A::DILATED_MAX)).0 & A::DILATED_MAX)
+    }
+}
+
 impl<A> fmt::Display for DilatedInt<A> where A: DilationMethod, A::Dilated: fmt::Display {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
It's possible to add the value 1 to a dilated int in a more optimal way than the regular Add implementation.

Adding 1 can be implemented as: (dilated - DILATED_MAX) & DILATED_MAX
Whereas adding an arbitrary "rhs" is implemented as: (dilated + !DILATED_MAX + rhs) & DILATED_MAX

It's only 1 operation difference, but it's worth adding since this object could be on the user's critical path.

Subtract 1 is no different in terms of number of operations, but we'll add it for the sake of user code hygiene.