### PR TITLE
Added DILATED_MASK

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -89,6 +89,7 @@ macro_rules! impl_expand {
             const UNDILATED_MAX: Self::Undilated = <$undilated>::MAX;
             const DILATED_BITS: usize = Self::UNDILATED_BITS * $d;
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
+            const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
             const DILATED_ONE: Self::Dilated = 1;
 
             #[inline]

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -89,6 +89,7 @@ macro_rules! impl_fixed {
             const UNDILATED_MAX: Self::Undilated = internal::build_fixed_undilated_max::<$t, $d>() as $t;
             const DILATED_BITS: usize = Self::UNDILATED_BITS * $d;
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
+            const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
             const DILATED_ONE: Self::Dilated = 1;
 
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,20 @@ pub trait DilationMethod: Sized {
     /// ```
     const DILATED_MAX: Self::Dilated;
 
+    /// A mask of all dilated bits, including 0 bits
+    /// 
+    /// This constant holds a set of consecutive N 1 bits, where N is equal to
+    /// [DilationMethod::DILATED_BITS].
+    /// 
+    /// # Examples
+    /// ```
+    /// use dilate::*;
+    /// 
+    /// assert_eq!(Expand::<u8, 3>::DILATED_MASK, 0xffffff);
+    /// assert_eq!(Fixed::<u16, 3>::DILATED_MASK, 0x7FFF);
+    /// ```
+    const DILATED_MASK: Self::Dilated;
+
     // The value 1 as Dilated type - not needed by the user
     #[doc(hidden)]
     const DILATED_ONE: Self::Dilated;


### PR DESCRIPTION
DILATED_MASK holds a set of consecutive N 1 bits, where N is equal to DilationMethod::DILATED_BITS.
