### PR TITLE
Explicit new() and value() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ let original: u8 = 0b1101;
 
 // Dilating
 let dilated = original.dilate_expand::<2>();
-assert_eq!(dilated.0, 0b1010001);
+assert_eq!(dilated.value(), 0b1010001);
 
 // This is the actual dilated type
 assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>(0b1010001));
@@ -76,7 +76,7 @@ let original: u8 = 0b1011;
 
 // Dilating
 let dilated = original.dilate_expand::<3>();
-assert_eq!(dilated.0, 0b1000001001);
+assert_eq!(dilated.value(), 0b1000001001);
 
 // This is the actual dilated type
 assert_eq!(dilated, DilatedInt::<Expand<u8, 3>>(0b1000001001));

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -275,13 +275,15 @@ mod tests {
                     }
 
                     #[test]
-                    #[should_panic(expected = "Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)")]
-                    #[allow(arithmetic_overflow)]
-                    fn new_too_large_panics() {
-                        if DilationMethodT::DILATED_MASK != DilatedT::MAX {
-                            DilatedIntT::new(DilationMethodT::DILATED_MASK + 1);
-                        } else {
-                            panic!("Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)");
+                    fn new_invalid_panics() {
+                        for bit in 0..DilatedT::BITS {
+                            if bit % $d != 0 {
+                                let dilated = 1 << bit;
+                                let result = std::panic::catch_unwind(|| DilatedIntT::new(dilated));
+                                if !result.is_err() {
+                                    panic!("Test did not panic as expected");
+                                }
+                            }
                         }
                     }
 
@@ -292,10 +294,6 @@ mod tests {
                         assert_eq!(DilatedIntT::new(VALUES[$d][2] as DilatedT).0, VALUES[$d][2] as DilatedT);
                         assert_eq!(DilatedIntT::new(VALUES[$d][3] as DilatedT).0, VALUES[$d][3] as DilatedT);
                         assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MAX).0, DilationMethodT::DILATED_MAX);
-
-                        // Note that it's okay to use bits that do not line up with DILATED_MAX as long as the total fits within DILATED_MASK
-                        // Bits that don't belong in DILATED_MAX are masked out
-                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MASK).0, DilationMethodT::DILATED_MAX);
                     }
 
                     #[test]

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -259,34 +259,51 @@ mod tests {
                     use crate::{DilationMethod, DilatedInt, Undilate, AddOne, SubOne};
                     use super::super::{Expand, DilateExpand};
 
+                    type DilationMethodT = Expand<$t, $d>;
+                    type DilatedIntT = DilatedInt<DilationMethodT>;
+                    type DilatedT = <DilationMethodT as DilationMethod>::Dilated;
+
                     #[test]
                     fn undilated_max_is_correct() {
-                        assert_eq!(Expand::<$t, $d>::UNDILATED_MAX, TestData::<Expand<$t, $d>>::undilated_max());
+                        assert_eq!(DilationMethodT::UNDILATED_MAX, TestData::<DilationMethodT>::undilated_max());
                     }
 
                     #[test]
                     fn dilated_max_is_correct() {
-                        assert_eq!(Expand::<$t, $d>::DILATED_MAX, TestData::<Expand<$t, $d>>::dilated_max());
+                        assert_eq!(DilationMethodT::DILATED_MAX, TestData::<DilationMethodT>::dilated_max());
                     }
 
                     #[test]
-                    fn add_one_is_correct() {
-                        for i in 0..10 {
-                            let value = VALUES[$d][i] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
-                            let value_add_one = VALUES[$d][i + 1] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
-                            assert_eq!(DilatedInt::<Expand<$t, $d>>(value).add_one().0, value_add_one);
+                    #[should_panic(expected = "Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)")]
+                    #[allow(arithmetic_overflow)]
+                    fn new_too_large_panics() {
+                        if DilationMethodT::DILATED_MASK != DilatedT::MAX {
+                            DilatedIntT::new(DilationMethodT::DILATED_MASK + 1);
+                        } else {
+                            panic!("Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)");
                         }
-                        assert_eq!(DilatedInt::<Expand<$t, $d>>(Expand::<$t, $d>::DILATED_MAX).add_one().0, 0);
                     }
 
                     #[test]
-                    fn sub_one_is_correct() {
-                        for i in 10..0 {
-                            let value = VALUES[$d][i] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
-                            let value_sub_one = VALUES[$d][i - 1] as <Expand::<$t, $d> as DilationMethod>::Dilated & Expand::<$t, $d>::DILATED_MAX;
-                            assert_eq!(DilatedInt::<Expand<$t, $d>>(value).sub_one().0, value_sub_one);
-                        }
-                        assert_eq!(DilatedInt::<Expand<$t, $d>>(0).sub_one().0, Expand::<$t, $d>::DILATED_MAX);
+                    fn new_valid_stores_correct_value() {
+                        assert_eq!(DilatedIntT::new(VALUES[$d][0] as DilatedT).0, VALUES[$d][0] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][1] as DilatedT).0, VALUES[$d][1] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][2] as DilatedT).0, VALUES[$d][2] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][3] as DilatedT).0, VALUES[$d][3] as DilatedT);
+                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MAX).0, DilationMethodT::DILATED_MAX);
+
+                        // Note that it's okay to use bits that do not line up with DILATED_MAX as long as the total fits within DILATED_MASK
+                        // Bits that don't belong in DILATED_MAX are masked out
+                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MASK).0, DilationMethodT::DILATED_MAX);
+                    }
+
+                    #[test]
+                    fn value_returns_unmodified_value() {
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][0] as DilatedT).value(), VALUES[$d][0] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][1] as DilatedT).value(), VALUES[$d][1] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][2] as DilatedT).value(), VALUES[$d][2] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][3] as DilatedT).value(), VALUES[$d][3] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(DilationMethodT::DILATED_MAX).value(), DilationMethodT::DILATED_MAX);
                     }
 
                     #[test]
@@ -295,9 +312,9 @@ mod tests {
                         for (undilated_a, dilated_a) in DILATION_TEST_CASES[$d].iter() {
                             for (undilated_b, dilated_b) in DILATION_TEST_CASES[$d].iter() {
                                 let undilated = (*undilated_a ^ *undilated_b) as $t;
-                                let dilated = (*dilated_a ^ *dilated_b) as <Expand<$t, $d> as DilationMethod>::Dilated & TestData::<Expand<$t, $d>>::dilated_max();
-                                assert_eq!(Expand::<$t, $d>::dilate(undilated), DilatedInt::<Expand<$t, $d>>(dilated));
-                                assert_eq!(undilated.dilate_expand::<$d>(), DilatedInt::<Expand<$t, $d>>(dilated));
+                                let dilated = (*dilated_a ^ *dilated_b) as DilatedT & TestData::<DilationMethodT>::dilated_max();
+                                assert_eq!(DilationMethodT::dilate(undilated), DilatedInt::<DilationMethodT>(dilated));
+                                assert_eq!(undilated.dilate_expand::<$d>(), DilatedInt::<DilationMethodT>(dilated));
                             }
                         }
                     }
@@ -308,9 +325,9 @@ mod tests {
                         for (undilated_a, dilated_a) in DILATION_TEST_CASES[$d].iter() {
                             for (undilated_b, dilated_b) in DILATION_TEST_CASES[$d].iter() {
                                 let undilated = (*undilated_a ^ *undilated_b) as $t;
-                                let dilated = (*dilated_a ^ *dilated_b) as <Expand<$t, $d> as DilationMethod>::Dilated & TestData::<Expand<$t, $d>>::dilated_max();
-                                assert_eq!(Expand::<$t, $d>::undilate(DilatedInt::<Expand<$t, $d>>(dilated)), undilated);
-                                assert_eq!(DilatedInt::<Expand<$t, $d>>(dilated).undilate(), undilated);
+                                let dilated = (*dilated_a ^ *dilated_b) as DilatedT & TestData::<DilationMethodT>::dilated_max();
+                                assert_eq!(DilationMethodT::undilate(DilatedInt::<DilationMethodT>(dilated)), undilated);
+                                assert_eq!(DilatedInt::<DilationMethodT>(dilated).undilate(), undilated);
                             }
                         }
                     }
@@ -327,15 +344,14 @@ mod tests {
                             (VALUES[$d][2], VALUES[$d][0], VALUES[$d][2]), // 2 + 0 = 2
                             (VALUES[$d][2], VALUES[$d][1], VALUES[$d][3]), // 2 + 1 = 3
                             (VALUES[$d][2], VALUES[$d][2], VALUES[$d][4]), // 2 + 2 = 4
-                            (TestData::<Expand<$t, $d>>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max + 1 = 0
+                            (TestData::<DilationMethodT>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max + 1 = 0
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Expand<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Expand<$t, $d> as DilationMethod>::Dilated;
-                            assert_eq!(DilatedInt::<Expand<$t, $d>>(*a as DilatedT) + DilatedInt::<Expand<$t, $d>>(*b as DilatedT), DilatedInt::<Expand<$t, $d>>(*ans as DilatedT));
+                            assert_eq!(DilatedInt::<DilationMethodT>(*a as DilatedT) + DilatedInt::<DilationMethodT>(*b as DilatedT), DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -351,17 +367,16 @@ mod tests {
                             (VALUES[$d][2], VALUES[$d][0], VALUES[$d][2]), // 2 += 0 = 2
                             (VALUES[$d][2], VALUES[$d][1], VALUES[$d][3]), // 2 += 1 = 3
                             (VALUES[$d][2], VALUES[$d][2], VALUES[$d][4]), // 2 += 2 = 4
-                            (TestData::<Expand<$t, $d>>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max += 1 = 0
+                            (TestData::<DilationMethodT>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max += 1 = 0
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Expand<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Expand<$t, $d> as DilationMethod>::Dilated;
-                            let mut assigned = DilatedInt::<Expand<$t, $d>>(*a as DilatedT);
-                            assigned += DilatedInt::<Expand<$t, $d>>(*b as DilatedT);
-                            assert_eq!(assigned, DilatedInt::<Expand<$t, $d>>(*ans as DilatedT));
+                            let mut assigned = DilatedInt::<DilationMethodT>(*a as DilatedT);
+                            assigned += DilatedInt::<DilationMethodT>(*b as DilatedT);
+                            assert_eq!(assigned, DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -377,15 +392,14 @@ mod tests {
                             (VALUES[$d][4], VALUES[$d][0], VALUES[$d][4]), // 4 - 0 = 4
                             (VALUES[$d][4], VALUES[$d][1], VALUES[$d][3]), // 4 - 1 = 3
                             (VALUES[$d][4], VALUES[$d][2], VALUES[$d][2]), // 4 - 2 = 2
-                            (VALUES[$d][0], VALUES[$d][1], TestData::<Expand<$t, $d>>::dilated_max() as u128), // 0 - 1 = max
+                            (VALUES[$d][0], VALUES[$d][1], TestData::<DilationMethodT>::dilated_max() as u128), // 0 - 1 = max
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Expand<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Expand<$t, $d> as DilationMethod>::Dilated;
-                            assert_eq!(DilatedInt::<Expand<$t, $d>>(*a as DilatedT) - DilatedInt::<Expand<$t, $d>>(*b as DilatedT), DilatedInt::<Expand<$t, $d>>(*ans as DilatedT));
+                            assert_eq!(DilatedInt::<DilationMethodT>(*a as DilatedT) - DilatedInt::<DilationMethodT>(*b as DilatedT), DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -401,18 +415,37 @@ mod tests {
                             (VALUES[$d][4], VALUES[$d][0], VALUES[$d][4]), // 4 -= 0 = 4
                             (VALUES[$d][4], VALUES[$d][1], VALUES[$d][3]), // 4 -= 1 = 3
                             (VALUES[$d][4], VALUES[$d][2], VALUES[$d][2]), // 4 -= 2 = 2
-                            (VALUES[$d][0], VALUES[$d][1], TestData::<Expand<$t, $d>>::dilated_max() as u128), // 0 -= 1 = max
+                            (VALUES[$d][0], VALUES[$d][1], TestData::<DilationMethodT>::dilated_max() as u128), // 0 -= 1 = max
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Expand<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Expand<$t, $d> as DilationMethod>::Dilated;
-                            let mut assigned = DilatedInt::<Expand<$t, $d>>(*a as DilatedT);
-                            assigned -= DilatedInt::<Expand<$t, $d>>(*b as DilatedT);
-                            assert_eq!(assigned, DilatedInt::<Expand<$t, $d>>(*ans as DilatedT));
+                            let mut assigned = DilatedInt::<DilationMethodT>(*a as DilatedT);
+                            assigned -= DilatedInt::<DilationMethodT>(*b as DilatedT);
+                            assert_eq!(assigned, DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
+                    }
+
+                    #[test]
+                    fn add_one_is_correct() {
+                        for i in 0..10 {
+                            let value = VALUES[$d][i] as DilatedT & DilationMethodT::DILATED_MAX;
+                            let value_add_one = VALUES[$d][i + 1] as DilatedT & DilationMethodT::DILATED_MAX;
+                            assert_eq!(DilatedInt::<DilationMethodT>(value).add_one().0, value_add_one);
+                        }
+                        assert_eq!(DilatedInt::<DilationMethodT>(DilationMethodT::DILATED_MAX).add_one().0, 0);
+                    }
+
+                    #[test]
+                    fn sub_one_is_correct() {
+                        for i in 10..0 {
+                            let value = VALUES[$d][i] as DilatedT & DilationMethodT::DILATED_MAX;
+                            let value_sub_one = VALUES[$d][i - 1] as DilatedT & DilationMethodT::DILATED_MAX;
+                            assert_eq!(DilatedInt::<DilationMethodT>(value).sub_one().0, value_sub_one);
+                        }
+                        assert_eq!(DilatedInt::<DilationMethodT>(0).sub_one().0, DilationMethodT::DILATED_MAX);
                     }
                 }
             }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -69,8 +69,8 @@ use crate::{internal, DilatableType, DilationMethod, DilatedInt};
 /// let original: u8 = 0b1101;
 /// let dilated = Expand::<u8, 2>::dilate(original);
 ///
-/// assert_eq!(dilated.0, 0b01010001);
-/// assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>(0b01010001));
+/// assert_eq!(dilated.value(), 0b01010001);
+/// assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>::new(0b01010001));
 /// 
 /// assert_eq!(Expand::<u8, 2>::undilate(dilated), original);
 /// ```
@@ -140,8 +140,8 @@ pub trait DilateExpand: DilatableType {
     ///
     /// let value: u8 = 0b1101;
     ///
-    /// assert_eq!(value.dilate_expand::<2>(), DilatedInt::<Expand<u8, 2>>(0b01010001));
-    /// assert_eq!(value.dilate_expand::<2>().0, 0b01010001);
+    /// assert_eq!(value.dilate_expand::<2>(), DilatedInt::<Expand<u8, 2>>::new(0b01010001));
+    /// assert_eq!(value.dilate_expand::<2>().value(), 0b01010001);
     /// ```
     ///
     /// # The Storage Type

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -90,6 +90,7 @@ macro_rules! impl_expand {
             const DILATED_BITS: usize = Self::UNDILATED_BITS * $d;
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
             const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
+            const DILATED_ZERO: Self::Dilated = 0;
             const DILATED_ONE: Self::Dilated = 1;
 
             #[inline]

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -271,34 +271,51 @@ mod tests {
                     use crate::{DilationMethod, DilatedInt, Undilate, AddOne, SubOne};
                     use super::super::{Fixed, DilateFixed};
 
+                    type DilationMethodT = Fixed<$t, $d>;
+                    type DilatedIntT = DilatedInt<DilationMethodT>;
+                    type DilatedT = <DilationMethodT as DilationMethod>::Dilated;
+
                     #[test]
                     fn undilated_max_is_correct() {
-                        assert_eq!(Fixed::<$t, $d>::UNDILATED_MAX, TestData::<Fixed<$t, $d>>::undilated_max());
+                        assert_eq!(DilationMethodT::UNDILATED_MAX, TestData::<DilationMethodT>::undilated_max());
                     }
 
                     #[test]
                     fn dilated_max_is_correct() {
-                        assert_eq!(Fixed::<$t, $d>::DILATED_MAX, TestData::<Fixed<$t, $d>>::dilated_max());
+                        assert_eq!(DilationMethodT::DILATED_MAX, TestData::<DilationMethodT>::dilated_max());
                     }
 
                     #[test]
-                    fn add_one_is_correct() {
-                        for i in 0..10 {
-                            let value = VALUES[$d][i] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
-                            let value_add_one = VALUES[$d][i + 1] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
-                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(value).add_one().0, value_add_one);
+                    #[should_panic(expected = "Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)")]
+                    #[allow(arithmetic_overflow)]
+                    fn new_too_large_panics() {
+                        if DilationMethodT::DILATED_MASK != DilatedT::MAX {
+                            DilatedIntT::new(DilationMethodT::DILATED_MASK + 1);
+                        } else {
+                            panic!("Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)");
                         }
-                        assert_eq!(DilatedInt::<Fixed<$t, $d>>(Fixed::<$t, $d>::DILATED_MAX).add_one().0, 0);
                     }
 
                     #[test]
-                    fn sub_one_is_correct() {
-                        for i in 10..0 {
-                            let value = VALUES[$d][i] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
-                            let value_sub_one = VALUES[$d][i - 1] as <Fixed::<$t, $d> as DilationMethod>::Dilated & Fixed::<$t, $d>::DILATED_MAX;
-                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(value).sub_one().0, value_sub_one);
-                        }
-                        assert_eq!(DilatedInt::<Fixed<$t, $d>>(0).sub_one().0, Fixed::<$t, $d>::DILATED_MAX);
+                    fn new_valid_stores_correct_value() {
+                        assert_eq!(DilatedIntT::new(VALUES[$d][0] as DilatedT).0, VALUES[$d][0] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][1] as DilatedT).0, VALUES[$d][1] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][2] as DilatedT).0, VALUES[$d][2] as DilatedT);
+                        assert_eq!(DilatedIntT::new(VALUES[$d][3] as DilatedT).0, VALUES[$d][3] as DilatedT);
+                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MAX).0, DilationMethodT::DILATED_MAX);
+
+                        // Note that it's okay to use bits that do not line up with DILATED_MAX as long as the total fits within DILATED_MASK
+                        // Bits that don't belong in DILATED_MAX are masked out
+                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MASK).0, DilationMethodT::DILATED_MAX);
+                    }
+
+                    #[test]
+                    fn value_returns_unmodified_value() {
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][0] as DilatedT).value(), VALUES[$d][0] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][1] as DilatedT).value(), VALUES[$d][1] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][2] as DilatedT).value(), VALUES[$d][2] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(VALUES[$d][3] as DilatedT).value(), VALUES[$d][3] as DilatedT);
+                        assert_eq!(DilatedInt::<DilationMethodT>(DilationMethodT::DILATED_MAX).value(), DilationMethodT::DILATED_MAX);
                     }
 
                     // Unique to Fixed dilations
@@ -306,7 +323,7 @@ mod tests {
                     #[should_panic(expected = "Attempting to dilate a value exceeds maximum (See DilationMethod::UNDILATED_MAX)")]
                     fn dilate_too_large_a_should_panic() {
                         if $d != 1 {
-                            Fixed::<$t, $d>::dilate(TestData::<Fixed<$t, $d>>::undilated_max() + 1);
+                            DilationMethodT::dilate(TestData::<DilationMethodT>::undilated_max() + 1);
                         } else {
                             // D1 will never panic because the maximum dilatable value is equal to T::MAX
                             // So we'll hack a panic in here
@@ -319,7 +336,7 @@ mod tests {
                     #[should_panic(expected = "Attempting to dilate a value exceeds maximum (See DilationMethod::UNDILATED_MAX)")]
                     fn dilate_too_large_b_should_panic() {
                         if $d != 1 {
-                            (TestData::<Fixed<$t, $d>>::undilated_max() + 1).dilate_fixed::<$d>();
+                            (TestData::<DilationMethodT>::undilated_max() + 1).dilate_fixed::<$d>();
                         } else {
                             // D1 will never panic because the maximum dilatable value is equal to T::MAX
                             // So we'll hack a panic in here
@@ -332,10 +349,10 @@ mod tests {
                         // To create many more valid test cases, we doubly iterate all of them and xor the values
                         for (undilated_a, dilated_a) in DILATION_TEST_CASES[$d].iter() {
                             for (undilated_b, dilated_b) in DILATION_TEST_CASES[$d].iter() {
-                                let undilated = (*undilated_a ^ *undilated_b) as $t & TestData::<Fixed<$t, $d>>::undilated_max();
-                                let dilated = (*dilated_a ^ *dilated_b) as <Fixed<$t, $d> as DilationMethod>::Dilated & TestData::<Fixed<$t, $d>>::dilated_max();
-                                assert_eq!(Fixed::<$t, $d>::dilate(undilated), DilatedInt::<Fixed<$t, $d>>(dilated));
-                                assert_eq!(undilated.dilate_fixed::<$d>(), DilatedInt::<Fixed<$t, $d>>(dilated));
+                                let undilated = (*undilated_a ^ *undilated_b) as $t & TestData::<DilationMethodT>::undilated_max();
+                                let dilated = (*dilated_a ^ *dilated_b) as DilatedT & TestData::<DilationMethodT>::dilated_max();
+                                assert_eq!(DilationMethod::dilate(undilated), DilatedInt::<DilationMethodT>(dilated));
+                                assert_eq!(undilated.dilate_fixed::<$d>(), DilatedInt::<DilationMethodT>(dilated));
                             }
                         }
                     }
@@ -345,10 +362,10 @@ mod tests {
                         // To create many more valid test cases, we doubly iterate all of them and xor the values
                         for (undilated_a, dilated_a) in DILATION_TEST_CASES[$d].iter() {
                             for (undilated_b, dilated_b) in DILATION_TEST_CASES[$d].iter() {
-                                let undilated = (*undilated_a ^ *undilated_b) as $t & TestData::<Fixed<$t, $d>>::undilated_max();
-                                let dilated = (*dilated_a ^ *dilated_b) as <Fixed<$t, $d> as DilationMethod>::Dilated & TestData::<Fixed<$t, $d>>::dilated_max();
-                                assert_eq!(Fixed::<$t, $d>::undilate(DilatedInt::<Fixed<$t, $d>>(dilated)), undilated);
-                                assert_eq!(DilatedInt::<Fixed<$t, $d>>(dilated).undilate(), undilated);
+                                let undilated = (*undilated_a ^ *undilated_b) as $t & TestData::<DilationMethodT>::undilated_max();
+                                let dilated = (*dilated_a ^ *dilated_b) as DilatedT & TestData::<DilationMethodT>::dilated_max();
+                                assert_eq!(DilationMethod::undilate(DilatedInt::<DilationMethodT>(dilated)), undilated);
+                                assert_eq!(DilatedInt::<DilationMethodT>(dilated).undilate(), undilated);
                             }
                         }
                     }
@@ -365,15 +382,14 @@ mod tests {
                             (VALUES[$d][2], VALUES[$d][0], VALUES[$d][2]), // 2 + 0 = 2
                             (VALUES[$d][2], VALUES[$d][1], VALUES[$d][3]), // 2 + 1 = 3
                             (VALUES[$d][2], VALUES[$d][2], VALUES[$d][4]), // 2 + 2 = 4
-                            (TestData::<Fixed<$t, $d>>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max + 1 = 0
+                            (TestData::<DilationMethodT>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max + 1 = 0
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Fixed<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Fixed<$t, $d> as DilationMethod>::Dilated;
-                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(*a as DilatedT) + DilatedInt::<Fixed<$t, $d>>(*b as DilatedT), DilatedInt::<Fixed<$t, $d>>(*ans as DilatedT));
+                            assert_eq!(DilatedInt::<DilationMethodT>(*a as DilatedT) + DilatedInt::<DilationMethodT>(*b as DilatedT), DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -389,17 +405,16 @@ mod tests {
                             (VALUES[$d][2], VALUES[$d][0], VALUES[$d][2]), // 2 += 0 = 2
                             (VALUES[$d][2], VALUES[$d][1], VALUES[$d][3]), // 2 += 1 = 3
                             (VALUES[$d][2], VALUES[$d][2], VALUES[$d][4]), // 2 += 2 = 4
-                            (TestData::<Fixed<$t, $d>>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max += 1 = 0
+                            (TestData::<DilationMethodT>::dilated_max() as u128, VALUES[$d][1], VALUES[$d][0]), // max += 1 = 0
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Fixed<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Fixed<$t, $d> as DilationMethod>::Dilated;
-                            let mut assigned = DilatedInt::<Fixed<$t, $d>>(*a as DilatedT);
-                            assigned += DilatedInt::<Fixed<$t, $d>>(*b as DilatedT);
-                            assert_eq!(assigned, DilatedInt::<Fixed<$t, $d>>(*ans as DilatedT));
+                            let mut assigned = DilatedInt::<DilationMethodT>(*a as DilatedT);
+                            assigned += DilatedInt::<DilationMethodT>(*b as DilatedT);
+                            assert_eq!(assigned, DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -415,15 +430,14 @@ mod tests {
                             (VALUES[$d][4], VALUES[$d][0], VALUES[$d][4]), // 4 - 0 = 4
                             (VALUES[$d][4], VALUES[$d][1], VALUES[$d][3]), // 4 - 1 = 3
                             (VALUES[$d][4], VALUES[$d][2], VALUES[$d][2]), // 4 - 2 = 2
-                            (VALUES[$d][0], VALUES[$d][1], TestData::<Fixed<$t, $d>>::dilated_max() as u128), // 0 - 1 = max
+                            (VALUES[$d][0], VALUES[$d][1], TestData::<DilationMethodT>::dilated_max() as u128), // 0 - 1 = max
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Fixed<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Fixed<$t, $d> as DilationMethod>::Dilated;
-                            assert_eq!(DilatedInt::<Fixed<$t, $d>>(*a as DilatedT) - DilatedInt::<Fixed<$t, $d>>(*b as DilatedT), DilatedInt::<Fixed<$t, $d>>(*ans as DilatedT));
+                            assert_eq!(DilatedInt::<DilationMethodT>(*a as DilatedT) - DilatedInt::<DilationMethodT>(*b as DilatedT), DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
                     }
 
@@ -439,18 +453,37 @@ mod tests {
                             (VALUES[$d][4], VALUES[$d][0], VALUES[$d][4]), // 4 -= 0 = 4
                             (VALUES[$d][4], VALUES[$d][1], VALUES[$d][3]), // 4 -= 1 = 3
                             (VALUES[$d][4], VALUES[$d][2], VALUES[$d][2]), // 4 -= 2 = 2
-                            (VALUES[$d][0], VALUES[$d][1], TestData::<Fixed<$t, $d>>::dilated_max() as u128), // 0 -= 1 = max
+                            (VALUES[$d][0], VALUES[$d][1], TestData::<DilationMethodT>::dilated_max() as u128), // 0 -= 1 = max
                         ];
 
                         // Some formats won't support arithmetic (for example u8 D8)
                         // So we have to filter to ensure they support all numbers involved with a particular test case
-                        let mask_u128 = TestData::<Fixed<$t, $d>>::dilated_max() as u128;
+                        let mask_u128 = TestData::<DilationMethodT>::dilated_max() as u128;
                         for (a, b, ans) in test_cases.iter().filter(|(a, b, ans)| *a <= mask_u128 && *b <= mask_u128 && *ans <= mask_u128) {
-                            type DilatedT = <Fixed<$t, $d> as DilationMethod>::Dilated;
-                            let mut assigned = DilatedInt::<Fixed<$t, $d>>(*a as DilatedT);
-                            assigned -= DilatedInt::<Fixed<$t, $d>>(*b as DilatedT);
-                            assert_eq!(assigned, DilatedInt::<Fixed<$t, $d>>(*ans as DilatedT));
+                            let mut assigned = DilatedInt::<DilationMethodT>(*a as DilatedT);
+                            assigned -= DilatedInt::<DilationMethodT>(*b as DilatedT);
+                            assert_eq!(assigned, DilatedInt::<DilationMethodT>(*ans as DilatedT));
                         }
+                    }
+
+                    #[test]
+                    fn add_one_is_correct() {
+                        for i in 0..10 {
+                            let value = VALUES[$d][i] as DilatedT & DilationMethodT::DILATED_MAX;
+                            let value_add_one = VALUES[$d][i + 1] as DilatedT & DilationMethodT::DILATED_MAX;
+                            assert_eq!(DilatedInt::<DilationMethodT>(value).add_one().0, value_add_one);
+                        }
+                        assert_eq!(DilatedInt::<DilationMethodT>(DilationMethodT::DILATED_MAX).add_one().0, 0);
+                    }
+
+                    #[test]
+                    fn sub_one_is_correct() {
+                        for i in 10..0 {
+                            let value = VALUES[$d][i] as DilatedT & DilationMethodT::DILATED_MAX;
+                            let value_sub_one = VALUES[$d][i - 1] as DilatedT & DilationMethodT::DILATED_MAX;
+                            assert_eq!(DilatedInt::<DilationMethodT>(value).sub_one().0, value_sub_one);
+                        }
+                        assert_eq!(DilatedInt::<DilationMethodT>(0).sub_one().0, DilationMethodT::DILATED_MAX);
                     }
                 }
             }

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -90,6 +90,7 @@ macro_rules! impl_fixed {
             const DILATED_BITS: usize = Self::UNDILATED_BITS * $d;
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
             const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
+            const DILATED_ZERO: Self::Dilated = 0;
             const DILATED_ONE: Self::Dilated = 1;
 
             #[inline]

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -69,8 +69,8 @@ use crate::{internal, DilatableType, DilationMethod, DilatedInt};
 /// let original: u16 = 0b1101;
 /// let dilated = Fixed::<u16, 2>::dilate(original);
 ///
-/// assert_eq!(dilated.0, 0b01010001);
-/// assert_eq!(dilated, DilatedInt::<Fixed<u16, 2>>(0b01010001));
+/// assert_eq!(dilated.value(), 0b01010001);
+/// assert_eq!(dilated, DilatedInt::<Fixed<u16, 2>>::new(0b01010001));
 /// 
 /// assert_eq!(Fixed::<u16, 2>::undilate(dilated), original);
 /// ```
@@ -142,8 +142,8 @@ pub trait DilateFixed: DilatableType {
     ///
     /// let value: u16 = 0b1101;
     ///
-    /// assert_eq!(value.dilate_fixed::<2>(), DilatedInt::<Fixed<u16, 2>>(0b01010001));
-    /// assert_eq!(value.dilate_fixed::<2>().0, 0b01010001);
+    /// assert_eq!(value.dilate_fixed::<2>(), DilatedInt::<Fixed<u16, 2>>::new(0b01010001));
+    /// assert_eq!(value.dilate_fixed::<2>().value(), 0b01010001);
     /// 
     /// // Panics with large values
     /// assert!(std::panic::catch_unwind(|| 0xffffu16.dilate_fixed::<2>()).is_err());

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -287,13 +287,15 @@ mod tests {
                     }
 
                     #[test]
-                    #[should_panic(expected = "Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)")]
-                    #[allow(arithmetic_overflow)]
-                    fn new_too_large_panics() {
-                        if DilationMethodT::DILATED_MASK != DilatedT::MAX {
-                            DilatedIntT::new(DilationMethodT::DILATED_MASK + 1);
-                        } else {
-                            panic!("Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)");
+                    fn new_invalid_panics() {
+                        for bit in 0..DilatedT::BITS {
+                            if bit % $d != 0 {
+                                let dilated = 1 << bit;
+                                let result = std::panic::catch_unwind(|| DilatedIntT::new(dilated));
+                                if !result.is_err() {
+                                    panic!("Test did not panic as expected");
+                                }
+                            }
                         }
                     }
 
@@ -304,10 +306,6 @@ mod tests {
                         assert_eq!(DilatedIntT::new(VALUES[$d][2] as DilatedT).0, VALUES[$d][2] as DilatedT);
                         assert_eq!(DilatedIntT::new(VALUES[$d][3] as DilatedT).0, VALUES[$d][3] as DilatedT);
                         assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MAX).0, DilationMethodT::DILATED_MAX);
-
-                        // Note that it's okay to use bits that do not line up with DILATED_MAX as long as the total fits within DILATED_MASK
-                        // Bits that don't belong in DILATED_MAX are masked out
-                        assert_eq!(DilatedIntT::new(DilationMethodT::DILATED_MASK).0, DilationMethodT::DILATED_MAX);
                     }
 
                     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,10 @@
 //! 
 //! // Dilating
 //! let dilated = original.dilate_expand::<2>();
-//! assert_eq!(dilated.0, 0b1010001);
+//! assert_eq!(dilated.value(), 0b1010001);
 //! 
 //! // This is the actual dilated type
-//! assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>(0b1010001));
+//! assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>::new(0b1010001));
 //! 
 //! // Undilating
 //! assert_eq!(dilated.undilate(), original);
@@ -121,10 +121,10 @@
 //! 
 //! // Dilating
 //! let dilated = original.dilate_expand::<3>();
-//! assert_eq!(dilated.0, 0b1000001001);
+//! assert_eq!(dilated.value(), 0b1000001001);
 //! 
 //! // This is the actual dilated type
-//! assert_eq!(dilated, DilatedInt::<Expand<u8, 3>>(0b1000001001));
+//! assert_eq!(dilated, DilatedInt::<Expand<u8, 3>>::new(0b1000001001));
 //! 
 //! // Undilating
 //! assert_eq!(dilated.undilate(), original);
@@ -264,11 +264,11 @@ pub trait DilationMethod: Sized {
     /// ```
     /// use dilate::*;
     /// 
-    /// assert_eq!(Expand::<u8, 2>::dilate(0b1101), DilatedInt::<Expand<u8, 2>>(0b01010001));
-    /// assert_eq!(Expand::<u8, 2>::dilate(0b1101).0, 0b01010001);
+    /// assert_eq!(Expand::<u8, 2>::dilate(0b1101), DilatedInt::<Expand<u8, 2>>::new(0b01010001));
+    /// assert_eq!(Expand::<u8, 2>::dilate(0b1101).value(), 0b01010001);
     /// 
-    /// assert_eq!(Fixed::<u16, 3>::dilate(0b1101), DilatedInt::<Fixed<u16, 3>>(0b001001000001));
-    /// assert_eq!(Fixed::<u16, 3>::dilate(0b1101).0, 0b001001000001);
+    /// assert_eq!(Fixed::<u16, 3>::dilate(0b1101), DilatedInt::<Fixed<u16, 3>>::new(0b001001000001));
+    /// assert_eq!(Fixed::<u16, 3>::dilate(0b1101).value(), 0b001001000001);
     /// ```
     /// 
     /// See also [DilateExpand::dilate_expand()], [DilateFixed::dilate_fixed()]
@@ -320,8 +320,8 @@ pub trait DilationMethod: Sized {
 /// let original: u8 = 0b1101;
 /// 
 /// let dilated = original.dilate_expand::<2>();
-/// assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>(0b1010001));
-/// assert_eq!(dilated.0, 0b1010001);
+/// assert_eq!(dilated, DilatedInt::<Expand<u8, 2>>::new(0b1010001));
+/// assert_eq!(dilated.value(), 0b1010001);
 /// 
 /// assert_eq!(dilated.undilate(), original);
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,22 @@ pub trait DilationMethod: Sized {
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DilatedInt<A>(pub A::Dilated) where A: DilationMethod;
 
+impl<DM> DilatedInt<DM>
+where
+    DM: DilationMethod,
+{
+    #[inline]
+    pub fn new(dilated: DM::Dilated) -> Self where DM::Dilated: Ord + BitAnd<Output = DM::Dilated> {
+        debug_assert!(dilated <= DM::DILATED_MASK, "Parameter 'dilated' exceeds maximum dilated mask (DilationMethod::DILATED_MASK)");
+        Self(dilated & DM::DILATED_MAX)
+    }
+
+    #[inline]
+    pub fn value(&self) -> DM::Dilated {
+        self.0
+    }
+}
+
 impl<A> fmt::Display for DilatedInt<A> where A: DilationMethod, A::Dilated: fmt::Display {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,10 @@ pub trait DilationMethod: Sized {
     /// ```
     const DILATED_MASK: Self::Dilated;
 
+    // The value 0 as Dilated type - not needed by the user
+    #[doc(hidden)]
+    const DILATED_ZERO: Self::Dilated;
+
     // The value 1 as Dilated type - not needed by the user
     #[doc(hidden)]
     const DILATED_ONE: Self::Dilated;


### PR DESCRIPTION
It is currently possible to insert an invalid value into the dilated int tuple struct. This leads to undefined behaviour when interacting with the dilated int either by decoding or using the arithmetic operators.

It is also possible to modify a dilated int at any point via the .0 member, leading to possible invalid dilated values. This leads to the same undefined behaviour.

Therefore, I'm adding an explicit new() and value() method to ensure that DilatedInt is always valid.