### PR TITLE
Add casting functions to dilation methods

### DIFF
--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -93,12 +93,12 @@ macro_rules! impl_fixed {
 
             #[inline]
             fn to_dilated(undilated: Self::Undilated) -> Self::Dilated {
-                undilated as Self::Dilated
+                undilated
             }
 
             #[inline]
             fn to_undilated(dilated: Self::Dilated) -> Self::Undilated {
-                dilated as Self::Undilated
+                dilated
             }
         
             #[inline]

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -92,6 +92,16 @@ macro_rules! impl_fixed {
             const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
 
             #[inline]
+            fn to_dilated(undilated: Self::Undilated) -> Self::Dilated {
+                undilated as Self::Dilated
+            }
+
+            #[inline]
+            fn to_undilated(dilated: Self::Dilated) -> Self::Undilated {
+                dilated as Self::Undilated
+            }
+        
+            #[inline]
             fn dilate(value: Self::Undilated) -> DilatedInt<Self> {
                 DilatedInt::<Self>(internal::dilate_implicit::<Self::Dilated, $d>(value))
             }
@@ -282,6 +292,7 @@ mod tests {
                     type DilationMethodT = Fixed<$t, $d>;
                     type DilatedIntT = DilatedInt<DilationMethodT>;
                     type DilatedT = <DilationMethodT as DilationMethod>::Dilated;
+                    type UndilatedT = <DilationMethodT as DilationMethod>::Undilated;
 
                     #[test]
                     fn undilated_max_is_correct() {
@@ -291,6 +302,28 @@ mod tests {
                     #[test]
                     fn dilated_max_is_correct() {
                         assert_eq!(DilationMethodT::DILATED_MAX, TestData::<DilationMethodT>::dilated_max());
+                    }
+
+                    #[test]
+                    fn to_dilated_is_correct() {
+                        assert_eq!(DilationMethodT::to_dilated(0), 0);
+                        assert_eq!(DilationMethodT::to_dilated(1), 1);
+                        assert_eq!(DilationMethodT::to_dilated(2), 2);
+                        assert_eq!(DilationMethodT::to_dilated(3), 3);
+
+                        // When using Fixed, moving from undilated to dilated is never lossy
+                        assert_eq!(DilationMethodT::to_dilated(UndilatedT::MAX), DilatedT::MAX);
+                    }
+
+                    #[test]
+                    fn to_undilated_is_correct() {
+                        assert_eq!(DilationMethodT::to_undilated(0), 0);
+                        assert_eq!(DilationMethodT::to_undilated(1), 1);
+                        assert_eq!(DilationMethodT::to_undilated(2), 2);
+                        assert_eq!(DilationMethodT::to_undilated(3), 3);
+
+                        // When using Fixed, moving from dilated to undilated is never lossy
+                        assert_eq!(DilationMethodT::to_undilated(DilatedT::MAX), UndilatedT::MAX);
                     }
 
                     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,24 @@ pub trait DilationMethod: Default + Copy + Eq + Ord {
     /// ```
     const DILATED_MASK: Self::Dilated;
 
+    /// This function casts an undilated integer to a dilated integer
+    /// 
+    /// No dilation process is carried out, this is simply a cast to the
+    /// dilated integer type.
+    fn to_dilated(undilated: Self::Undilated) -> Self::Dilated;
+
+    /// This function converts a dilated integer to an undilated integer
+    /// 
+    /// No undilation process is carried out, this is simply a cast to the
+    /// undilated integer type.
+    /// 
+    /// Additionally, this function is potentially lossy and should be used
+    /// only when you are certain that the conversion is valid or you don't
+    /// mind losing some bits. For more secure number casts, users may
+    /// prefer NumCast from the
+    /// [NumTraits](https://crates.io/crates/num-traits) crate.
+    fn to_undilated(dilated: Self::Dilated) -> Self::Undilated;
+
     /// This function carries out the dilation process, converting the
     /// [DilationMethod::Undilated] value to a [DilatedInt].
     ///


### PR DESCRIPTION
Although not necessary for the functionality in dilate, it may be useful to provide users with the ability to cast integers between undilated and dilated types. This PR includes trait functions `to_dilated()` and `to_undilated()`, plus `Expand` and `Fixed` implementations.