### PR TITLE
Switch out circleci rust orb for cimg docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
 version: 2.1
 
-orbs: 
-  rust: circleci/rust@1.6.0
-
-workflows:
-  production:
-    jobs:
-      - rust/lint-test-build:
-          release: true
-          version: 1.58.0
+jobs:
+  build:
+    docker:
+      - image: cimg/rust:1.63.0
+    steps:
+      - checkout
+      - run: cargo --version
+      - run:
+          name: Run Tests
+          command: "cargo test"


### PR DESCRIPTION
Update circleci config to use rust docker image for testing.