### PR TITLE
Add internal benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ std = []
 
 [dev-dependencies]
 paste = "1.0.6" # For generation of multi-dimensional, multi-type, test names
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "benches"
+harness = false

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,152 @@
+use std::sync::OnceLock;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use dilate::{DilateFixed, DilatedInt, DilationMethod, Fixed};
+
+pub trait BenchNumTraits {
+    fn from_usize(value: usize) -> Self;
+    fn to_usize(self) -> usize;
+}
+
+macro_rules! impl_num_traits {
+    ($($t:ty),+) => {$(
+        impl BenchNumTraits for $t {
+            #[inline(always)]
+            fn from_usize(value: usize) -> Self {
+                value as Self
+            }
+
+            #[inline(always)]
+            fn to_usize(self) -> usize {
+                self as usize
+            }
+        }
+    )+};
+}
+
+impl_num_traits!(u8, u16, u32, u64, u128);
+
+const UNDILATED_MAX: usize = 255;
+
+fn dilated_values(dimension: usize) -> &'static std::vec::Vec<usize> {
+    static DILATED_VALUES: OnceLock<[std::vec::Vec<usize>; 9]> = OnceLock::new();
+    &DILATED_VALUES.get_or_init(|| {
+        [
+            // D0 (not used)
+            std::vec::Vec::new(),
+
+            // D1 (not used)
+            std::vec::Vec::new(),
+
+            // D2 - D8
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<2>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<3>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<4>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<5>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<6>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<7>().value()).collect(),
+            (0..=UNDILATED_MAX).into_iter().map(|v| v.dilate_fixed::<8>().value()).collect(),
+        ]
+    })[dimension]
+}
+
+fn benchmark_dilate_undilate<FDil: Fn(usize) -> usize, FUndil: Fn(usize) -> usize>(
+    c: &mut Criterion,
+    d: usize,
+    crate_name: &str,
+    dilate: FDil,
+    undilate: FUndil,
+) {
+    let dilated_values = dilated_values(d);
+
+    c.bench_function(
+        format!("{}d dilate: {}", d, crate_name).as_str(),
+        |b| {
+            b.iter(|| {
+                for i in 0..=UNDILATED_MAX {
+                    dilate(i);
+                }
+            })
+        },
+    );
+
+    c.bench_function(
+        format!("{}d undilate: {}", d, crate_name).as_str(),
+        |b| {
+            b.iter(|| {
+                for i in 0..=UNDILATED_MAX {
+                    undilate(dilated_values[i]);
+                }
+            })
+        },
+    );
+}
+
+fn benchmark<const D: usize>(c: &mut Criterion)
+where
+    Fixed<u16, D>: DilationMethod,
+    Fixed<u32, D>: DilationMethod,
+    Fixed<u64, D>: DilationMethod,
+    Fixed<u128, D>: DilationMethod,
+    <Fixed<u16, D> as DilationMethod>::Dilated: BenchNumTraits,
+    <Fixed<u16, D> as DilationMethod>::Undilated: BenchNumTraits,
+    <Fixed<u32, D> as DilationMethod>::Dilated: BenchNumTraits,
+    <Fixed<u32, D> as DilationMethod>::Undilated: BenchNumTraits,
+    <Fixed<u64, D> as DilationMethod>::Dilated: BenchNumTraits,
+    <Fixed<u64, D> as DilationMethod>::Undilated: BenchNumTraits,
+    <Fixed<u128, D> as DilationMethod>::Dilated: BenchNumTraits,
+    <Fixed<u128, D> as DilationMethod>::Undilated: BenchNumTraits,
+{
+    benchmark_dilate_undilate(
+        c,
+        D,
+        "u16",
+        |i| black_box(Fixed::<u16, D>::dilate(black_box(<Fixed<u16, D> as DilationMethod>::Undilated::from_usize(i))).value().to_usize()),
+        |i| {
+            black_box(Fixed::<u16, D>::undilate(black_box(DilatedInt::<Fixed<u16, D>>::new(<Fixed<u16, D> as DilationMethod>::Dilated::from_usize(i)))).to_usize())
+        },
+    );
+    benchmark_dilate_undilate(
+        c,
+        D,
+        "u32",
+        |i| black_box(Fixed::<u32, D>::dilate(black_box(<Fixed<u32, D> as DilationMethod>::Undilated::from_usize(i))).value().to_usize()),
+        |i| {
+            black_box(Fixed::<u32, D>::undilate(black_box(DilatedInt::<Fixed<u32, D>>::new(<Fixed<u32, D> as DilationMethod>::Dilated::from_usize(i)))).to_usize())
+        },
+    );
+    benchmark_dilate_undilate(
+        c,
+        D,
+        "u64",
+        |i| black_box(Fixed::<u64, D>::dilate(black_box(<Fixed<u64, D> as DilationMethod>::Undilated::from_usize(i))).value().to_usize()),
+        |i| {
+            black_box(Fixed::<u64, D>::undilate(black_box(DilatedInt::<Fixed<u64, D>>::new(<Fixed<u64, D> as DilationMethod>::Dilated::from_usize(i)))).to_usize())
+        },
+    );
+    benchmark_dilate_undilate(
+        c,
+        D,
+        "u128",
+        |i| black_box(Fixed::<u128, D>::dilate(black_box(<Fixed<u128, D> as DilationMethod>::Undilated::from_usize(i))).value().to_usize()),
+        |i| {
+            black_box(Fixed::<u128, D>::undilate(black_box(DilatedInt::<Fixed<u128, D>>::new(<Fixed<u128, D> as DilationMethod>::Dilated::from_usize(i)))).to_usize())
+        },
+    );
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    benchmark::<2>(c);
+    benchmark::<3>(c);
+    benchmark::<4>(c);
+
+    benchmark::<8>(c); // Will force use of Dn methods
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(1000);
+    targets = criterion_benchmark
+);
+criterion_main!(benches);

--- a/benches/latest_benches.txt
+++ b/benches/latest_benches.txt
@@ -1,0 +1,218 @@
+2d dilate: u16          time:   [380.95 ns 385.07 ns 389.23 ns]
+                        change: [-22.849% -22.202% -21.512%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 4 outliers among 1000 measurements (0.40%)
+  4 (0.40%) high mild
+
+2d undilate: u16        time:   [330.65 ns 335.93 ns 341.30 ns]
+                        change: [-3.1310% -1.4255% +0.3616%] (p = 0.12 > 0.05)
+                        No change in performance detected.
+
+2d dilate: u32          time:   [301.78 ns 304.91 ns 308.28 ns]
+                        change: [-0.5688% +0.6219% +1.8728%] (p = 0.29 > 0.05)
+                        No change in performance detected.
+Found 124 outliers among 1000 measurements (12.40%)
+  23 (2.30%) high mild
+  101 (10.10%) high severe
+
+2d undilate: u32        time:   [305.31 ns 309.11 ns 313.18 ns]
+                        change: [-6.4458% -5.1793% -3.8686%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 132 outliers among 1000 measurements (13.20%)
+  26 (2.60%) high mild
+  106 (10.60%) high severe
+
+2d dilate: u64          time:   [280.47 ns 283.21 ns 286.15 ns]
+                        change: [-1.6839% -0.5052% +0.7557%] (p = 0.40 > 0.05)
+                        No change in performance detected.
+Found 93 outliers among 1000 measurements (9.30%)
+  21 (2.10%) high mild
+  72 (7.20%) high severe
+
+2d undilate: u64        time:   [341.76 ns 344.79 ns 348.03 ns]
+                        change: [-5.7863% -4.6832% -3.5674%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 71 outliers among 1000 measurements (7.10%)
+  14 (1.40%) high mild
+  57 (5.70%) high severe
+
+2d dilate: u128         time:   [362.99 ns 366.43 ns 370.20 ns]
+                        change: [-0.0856% +1.0165% +2.1864%] (p = 0.08 > 0.05)
+                        No change in performance detected.
+Found 119 outliers among 1000 measurements (11.90%)
+  27 (2.70%) high mild
+  92 (9.20%) high severe
+
+2d undilate: u128       time:   [806.34 ns 815.97 ns 826.39 ns]
+                        change: [-1.8368% -0.5482% +0.5783%] (p = 0.36 > 0.05)
+                        No change in performance detected.
+Found 69 outliers among 1000 measurements (6.90%)
+  12 (1.20%) high mild
+  57 (5.70%) high severe
+
+3d dilate: u16          time:   [354.39 ns 356.16 ns 358.02 ns]
+                        change: [+0.2789% +1.0880% +1.8654%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 127 outliers among 1000 measurements (12.70%)
+  29 (2.90%) high mild
+  98 (9.80%) high severe
+
+3d undilate: u16        time:   [417.00 ns 419.34 ns 421.79 ns]
+                        change: [-1.1482% -0.4804% +0.1461%] (p = 0.14 > 0.05)
+                        No change in performance detected.
+Found 47 outliers among 1000 measurements (4.70%)
+  40 (4.00%) high mild
+  7 (0.70%) high severe
+
+3d dilate: u32          time:   [299.84 ns 302.41 ns 305.22 ns]
+                        change: [+4.7094% +5.8172% +7.0436%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 142 outliers among 1000 measurements (14.20%)
+  28 (2.80%) high mild
+  114 (11.40%) high severe
+
+3d undilate: u32        time:   [271.67 ns 274.96 ns 278.36 ns]
+                        change: [-5.8600% -4.7198% -3.6291%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 38 outliers among 1000 measurements (3.80%)
+  37 (3.70%) high mild
+  1 (0.10%) high severe
+
+3d dilate: u64          time:   [287.49 ns 290.46 ns 293.65 ns]
+                        change: [-2.7371% -1.2813% +0.1995%] (p = 0.10 > 0.05)
+                        No change in performance detected.
+Found 112 outliers among 1000 measurements (11.20%)
+  21 (2.10%) high mild
+  91 (9.10%) high severe
+
+3d undilate: u64        time:   [328.82 ns 331.77 ns 334.91 ns]
+                        change: [-5.2587% -4.1159% -2.9104%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 48 outliers among 1000 measurements (4.80%)
+  34 (3.40%) high mild
+  14 (1.40%) high severe
+
+3d dilate: u128         time:   [368.65 ns 372.33 ns 376.26 ns]
+                        change: [+0.5133% +1.5907% +2.6639%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 122 outliers among 1000 measurements (12.20%)
+  35 (3.50%) high mild
+  87 (8.70%) high severe
+
+3d undilate: u128       time:   [739.27 ns 747.13 ns 755.08 ns]
+                        change: [+15.561% +16.711% +17.924%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 2 outliers among 1000 measurements (0.20%)
+  2 (0.20%) high mild
+
+4d dilate: u16          time:   [356.18 ns 358.26 ns 360.46 ns]
+                        change: [-1.9557% -1.3411% -0.7333%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 39 outliers among 1000 measurements (3.90%)
+  37 (3.70%) high mild
+  2 (0.20%) high severe
+
+4d undilate: u16        time:   [295.39 ns 298.62 ns 301.83 ns]
+                        change: [+0.4845% +1.6636% +2.8565%] (p = 0.01 < 0.05)
+                        Change within noise threshold.
+Found 1 outliers among 1000 measurements (0.10%)
+  1 (0.10%) high mild
+
+4d dilate: u32          time:   [317.10 ns 318.42 ns 319.81 ns]
+                        change: [-1.4582% -0.9465% -0.3863%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 88 outliers among 1000 measurements (8.80%)
+  54 (5.40%) high mild
+  34 (3.40%) high severe
+
+4d undilate: u32        time:   [441.10 ns 443.55 ns 446.05 ns]
+                        change: [-0.6568% -0.0226% +0.5916%] (p = 0.94 > 0.05)
+                        No change in performance detected.
+Found 59 outliers among 1000 measurements (5.90%)
+  54 (5.40%) high mild
+  5 (0.50%) high severe
+
+4d dilate: u64          time:   [179.95 ns 181.80 ns 183.81 ns]
+                        change: [-0.8515% +0.3396% +1.4699%] (p = 0.58 > 0.05)
+                        No change in performance detected.
+Found 94 outliers among 1000 measurements (9.40%)
+  25 (2.50%) high mild
+  69 (6.90%) high severe
+
+4d undilate: u64        time:   [431.34 ns 433.14 ns 435.04 ns]
+                        change: [-0.1338% +0.4121% +1.0500%] (p = 0.17 > 0.05)
+                        No change in performance detected.
+Found 82 outliers among 1000 measurements (8.20%)
+  45 (4.50%) high mild
+  37 (3.70%) high severe
+
+4d dilate: u128         time:   [283.92 ns 286.70 ns 289.69 ns]
+                        change: [-2.9541% -1.8613% -0.6862%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 52 outliers among 1000 measurements (5.20%)
+  31 (3.10%) high mild
+  21 (2.10%) high severe
+
+4d undilate: u128       time:   [700.81 ns 716.70 ns 733.04 ns]
+                        change: [-12.474% -10.219% -7.9786%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 144 outliers among 1000 measurements (14.40%)
+  136 (13.60%) high mild
+  8 (0.80%) high severe
+
+8d dilate: u16          time:   [241.36 ns 243.21 ns 245.10 ns]
+                        change: [-1.8712% -0.9797% -0.1270%] (p = 0.03 < 0.05)
+                        Change within noise threshold.
+Found 16 outliers among 1000 measurements (1.60%)
+  16 (1.60%) high mild
+
+8d undilate: u16        time:   [272.12 ns 276.05 ns 280.09 ns]
+                        change: [-1.6317% +0.0100% +1.6836%] (p = 0.99 > 0.05)
+                        No change in performance detected.
+
+8d dilate: u32          time:   [252.64 ns 254.03 ns 255.40 ns]
+                        change: [-1.5577% -0.8655% -0.1930%] (p = 0.01 < 0.05)
+                        Change within noise threshold.
+Found 71 outliers among 1000 measurements (7.10%)
+  25 (2.50%) low severe
+  10 (1.00%) low mild
+  22 (2.20%) high mild
+  14 (1.40%) high severe
+
+8d undilate: u32        time:   [256.83 ns 258.48 ns 260.24 ns]
+                        change: [-1.2880% -0.4975% +0.3253%] (p = 0.23 > 0.05)
+                        No change in performance detected.
+Found 93 outliers among 1000 measurements (9.30%)
+  60 (6.00%) high mild
+  33 (3.30%) high severe
+
+8d dilate: u64          time:   [144.35 ns 145.52 ns 146.78 ns]
+                        change: [-1.7189% -0.9140% -0.0439%] (p = 0.04 < 0.05)
+                        Change within noise threshold.
+Found 122 outliers among 1000 measurements (12.20%)
+  70 (7.00%) high mild
+  52 (5.20%) high severe
+
+8d undilate: u64        time:   [198.21 ns 200.11 ns 202.18 ns]
+                        change: [-3.9916% -3.0202% -2.0559%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 132 outliers among 1000 measurements (13.20%)
+  2 (0.20%) low mild
+  31 (3.10%) high mild
+  99 (9.90%) high severe
+
+8d dilate: u128         time:   [245.45 ns 248.45 ns 251.67 ns]
+                        change: [+9.1444% +10.503% +11.903%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 121 outliers among 1000 measurements (12.10%)
+  21 (2.10%) high mild
+  100 (10.00%) high severe
+
+8d undilate: u128       time:   [463.74 ns 465.85 ns 468.09 ns]
+                        change: [-0.2812% +0.3479% +1.0468%] (p = 0.29 > 0.05)
+                        No change in performance detected.
+Found 119 outliers among 1000 measurements (11.90%)
+  1 (0.10%) low mild
+  27 (2.70%) high mild
+  91 (9.10%) high severe
+

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -76,22 +76,22 @@ macro_rules! impl_expand {
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
             const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
 
-            #[inline]
+            #[inline(always)]
             fn to_dilated(undilated: Self::Undilated) -> Self::Dilated {
                 undilated as Self::Dilated
             }
 
-            #[inline]
+            #[inline(always)]
             fn to_undilated(dilated: Self::Dilated) -> Self::Undilated {
                 dilated as Self::Undilated
             }
         
-            #[inline]
+            #[inline(always)]
             fn dilate(value: Self::Undilated) -> DilatedInt<Self> {
                 DilatedInt::<Self>(internal::dilate_implicit::<Self::Dilated, $d>(value as Self::Dilated))
             }
 
-            #[inline]
+            #[inline(always)]
             fn undilate(value: DilatedInt<Self>) -> Self::Undilated {
                 internal::undilate_implicit::<Self::Dilated, $d>(value.0) as Self::Undilated
             }
@@ -193,7 +193,7 @@ pub trait DilateExpand: DilatableType {
     /// usize is interpreted as a u32 and will have the same expansion types as u32.
     ///
     /// See also [Expand<T, D>::dilate()](crate::DilationMethod::dilate())
-    #[inline]
+    #[inline(always)]
     fn dilate_expand<const D: usize>(self) -> DilatedInt<Expand<Self, D>>
     where
         Expand<Self, D>: DilationMethod<Undilated = Self>,

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -76,22 +76,22 @@ macro_rules! impl_fixed {
             const DILATED_MAX: Self::Dilated = internal::build_dilated_mask(Self::UNDILATED_BITS, $d) as Self::Dilated;
             const DILATED_MASK: Self::Dilated = Self::DILATED_MAX * ((1 << $d) - 1);
 
-            #[inline]
+            #[inline(always)]
             fn to_dilated(undilated: Self::Undilated) -> Self::Dilated {
                 undilated
             }
 
-            #[inline]
+            #[inline(always)]
             fn to_undilated(dilated: Self::Dilated) -> Self::Undilated {
                 dilated
             }
         
-            #[inline]
+            #[inline(always)]
             fn dilate(value: Self::Undilated) -> DilatedInt<Self> {
                 DilatedInt::<Self>(internal::dilate_implicit::<Self::Dilated, $d>(value))
             }
 
-            #[inline]
+            #[inline(always)]
             fn undilate(value: DilatedInt<Self>) -> Self::Undilated {
                 internal::undilate_implicit::<Self::Dilated, $d>(value.0)
             }
@@ -215,7 +215,7 @@ pub trait DilateFixed: DilatableType {
     /// usize is interpreted as a u32 and will have the same max dilatable value as u32.
     ///
     /// See also [Fixed<T, D>::dilate()](crate::DilationMethod::dilate())
-    #[inline]
+    #[inline(always)]
     fn dilate_fixed<const D: usize>(self) -> DilatedInt<Fixed<Self, D>>
     where
         Fixed<Self, D>: DilationMethod<Undilated = Self>,

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -39,31 +39,31 @@ pub trait NumTraits: Copy {
 macro_rules! impl_num_traits {
     ($($t:ty),+) => {$(
         impl NumTraits for $t {
-            #[inline]
+            #[inline(always)]
             fn zero() -> Self {
                 0
             }
-            #[inline]
+            #[inline(always)]
             fn one() -> Self {
                 1
             }
-            #[inline]
+            #[inline(always)]
             fn mul_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_mul(rhs)
             }
-            #[inline]
+            #[inline(always)]
             fn add_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_add(rhs)
             }
-            #[inline]
+            #[inline(always)]
             fn sub_wrapping(self, rhs: Self) -> Self {
                 self.wrapping_sub(rhs)
             }
-            #[inline]
+            #[inline(always)]
             fn bit_not(self) -> Self {
                 !self
             }
-            #[inline]
+            #[inline(always)]
             fn bit_and(self, rhs: Self) -> Self {
                 self & rhs
             }
@@ -75,7 +75,7 @@ impl_num_traits!(u8, u16, u32, u64, u128, usize);
 
 macro_rules! impl_dilate_dn {
     () => {
-        #[inline]
+        #[inline(always)]
         fn dilate_explicit_dn<const D: usize>(self) -> Self {
             debug_assert!(D > 2, "Generic parameter 'D' must be greater than 2");
             debug_assert!(
@@ -97,7 +97,7 @@ macro_rules! impl_dilate_dn {
 
 macro_rules! impl_undilate_dn {
     () => {
-        #[inline]
+        #[inline(always)]
         fn undilate_explicit_dn<const D: usize>(self) -> Self {
             debug_assert!(D > 1, "Generic parameter 'D' must be greater than 1");
             let mut v = self;
@@ -119,7 +119,7 @@ pub trait DilateExplicit: NumTraits {
 }
 
 impl DilateExplicit for u8 {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -133,7 +133,7 @@ impl DilateExplicit for u8 {
         v
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -151,7 +151,7 @@ impl DilateExplicit for u8 {
 }
 
 impl DilateExplicit for u16 {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -166,7 +166,7 @@ impl DilateExplicit for u16 {
         v
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -185,7 +185,7 @@ impl DilateExplicit for u16 {
 }
 
 impl DilateExplicit for u32 {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -201,7 +201,7 @@ impl DilateExplicit for u32 {
         v
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -221,7 +221,7 @@ impl DilateExplicit for u32 {
 }
 
 impl DilateExplicit for u64 {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -238,7 +238,7 @@ impl DilateExplicit for u64 {
         v
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -259,7 +259,7 @@ impl DilateExplicit for u64 {
 }
 
 impl DilateExplicit for u128 {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -277,7 +277,7 @@ impl DilateExplicit for u128 {
         v
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -299,7 +299,7 @@ impl DilateExplicit for u128 {
 }
 
 impl DilateExplicit for usize {
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d2(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 2>() as Self,
@@ -315,7 +315,7 @@ impl DilateExplicit for usize {
         r as usize
     }
 
-    #[inline]
+    #[inline(always)]
     fn dilate_explicit_d3(self) -> Self {
         debug_assert!(
             self <= build_fixed_undilated_max::<Self, 3>() as Self,
@@ -341,7 +341,7 @@ pub trait UndilateExplicit: NumTraits {
 }
 
 impl UndilateExplicit for u8 {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -350,7 +350,7 @@ impl UndilateExplicit for u8 {
         v >> 3
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -362,7 +362,7 @@ impl UndilateExplicit for u8 {
 }
 
 impl UndilateExplicit for u16 {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -372,7 +372,7 @@ impl UndilateExplicit for u16 {
         v >> 7
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -385,7 +385,7 @@ impl UndilateExplicit for u16 {
 }
 
 impl UndilateExplicit for u32 {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -396,7 +396,7 @@ impl UndilateExplicit for u32 {
         v >> 15
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -410,7 +410,7 @@ impl UndilateExplicit for u32 {
 }
 
 impl UndilateExplicit for u64 {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -422,7 +422,7 @@ impl UndilateExplicit for u64 {
         v >> 31
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -436,7 +436,7 @@ impl UndilateExplicit for u64 {
 }
 
 impl UndilateExplicit for u128 {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -449,7 +449,7 @@ impl UndilateExplicit for u128 {
         v >> 63
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         // See citation [1]
         let mut v = self;
@@ -464,7 +464,7 @@ impl UndilateExplicit for u128 {
 }
 
 impl UndilateExplicit for usize {
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d2(self) -> Self {
         #[cfg(target_pointer_width = "16")]
         let r = (self as u16).undilate_explicit_d2();
@@ -475,7 +475,7 @@ impl UndilateExplicit for usize {
         r as usize
     }
 
-    #[inline]
+    #[inline(always)]
     fn undilate_explicit_d3(self) -> Self {
         #[cfg(target_pointer_width = "16")]
         let r = (self as u16).undilate_explicit_d3();
@@ -489,7 +489,7 @@ impl UndilateExplicit for usize {
     impl_undilate_dn!();
 }
 
-#[inline]
+#[inline(always)]
 pub fn dilate_implicit<T, const D: usize>(value: T) -> T
 where
     T: DilateExplicit,
@@ -501,7 +501,7 @@ where
     }
 }
 
-#[inline]
+#[inline(always)]
 pub fn undilate_implicit<T, const D: usize>(value: T) -> T
 where
     T: UndilateExplicit,
@@ -518,7 +518,7 @@ where
 // Instantiations of each const function can therefore safely blind cast to the appropriate type
 
 // Calculates the maximum undilated value that fits into D-dilated T (fixed)
-#[inline]
+#[inline(always)]
 pub(crate) const fn build_fixed_undilated_max<T, const D: usize>() -> u128 {
     let bits_available = core::mem::size_of::<T>() * 8;
     let s_minus_1 = bits_available / D - 1;
@@ -531,7 +531,7 @@ pub(crate) const fn build_fixed_undilated_max<T, const D: usize>() -> u128 {
 
 // Builds a dilated mask with p repetitions of 1 bits separated by (q - 1) 0 bits
 // See Notation 4.2 in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn build_dilated_mask(p_repetitions: usize, q_width: usize) -> u128 {
     let mut r = p_repetitions;
     let mut v = 0;
@@ -544,7 +544,7 @@ pub(crate) const fn build_dilated_mask(p_repetitions: usize, q_width: usize) -> 
 
 // Calculates the maximum D-dilation round (total number of D-dilation rounds minus one)
 // See Algorithm 9 in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn dilate_max_round<T, const D: usize>() -> usize {
     let s = (core::mem::size_of::<T>() * 8) / D;
     s.ilog(D - 1) as usize
@@ -552,7 +552,7 @@ pub(crate) const fn dilate_max_round<T, const D: usize>() -> usize {
 
 // Calculates the D-dilation multiplier for each round
 // See section IV.D in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn dilate_mult<T, const D: usize>(round: usize) -> u128 {
     let round_inv = dilate_max_round::<T, D>() - round;
     build_dilated_mask(D - 1, (D - 1).pow(round_inv as u32 + 1))
@@ -560,7 +560,7 @@ pub(crate) const fn dilate_mult<T, const D: usize>(round: usize) -> u128 {
 
 // Calculates the D-dilation mask for each round
 // See section IV.D in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn dilate_mask<T, const D: usize>(round: usize) -> u128 {
     let round_inv = dilate_max_round::<T, D>() - round;
     let num_set_bits = (D - 1).pow(round_inv as u32);
@@ -578,7 +578,7 @@ pub(crate) const fn dilate_mask<T, const D: usize>(round: usize) -> u128 {
 
 // Calculates the maximum D-undilation round (total number of D-undilation rounds minus one)
 // See Algorithm 10 in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn undilate_max_round<T, const D: usize>() -> usize {
     let s = (core::mem::size_of::<T>() * 8) / D;
     s.ilog(D) as usize
@@ -586,14 +586,14 @@ pub(crate) const fn undilate_max_round<T, const D: usize>() -> usize {
 
 // Calculates the D-undilation multiplier for each round
 // See section IV.D in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn undilate_mult<T, const D: usize>(round: usize) -> u128 {
     build_dilated_mask(D, D.pow(round as u32) * (D - 1))
 }
 
 // Calculates the D-undilation mask for each round
 // See section IV.D in citation [1]
-#[inline]
+#[inline(always)]
 pub(crate) const fn undilate_mask<T, const D: usize>(round: usize) -> u128 {
     let s = (core::mem::size_of::<T>() * 8) / D;
     let num_blank_bits = D.pow(round as u32 + 1) * (D - 1);
@@ -619,7 +619,7 @@ pub(crate) const fn undilate_mask<T, const D: usize>(round: usize) -> u128 {
     v
 }
 
-#[inline]
+#[inline(always)]
 pub(crate) const fn undilate_shift<T, const D: usize>() -> usize {
     let s = (core::mem::size_of::<T>() * 8) / D;
     (D * (s - 1) + 1) - s
@@ -642,17 +642,17 @@ mod tests {
     macro_rules! impl_dilation_test_data {
         ($t:ty, $d:literal, $dil_max:literal, $num_rounds:literal, $(($round:literal, $mult:literal, $mask:literal)),*) => {
             impl DilationTestData<$t, $d> {
-                #[inline]
+                #[inline(always)]
                 fn dilated_max() -> $t {
                     $dil_max
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn num_rounds() -> usize {
                     $num_rounds
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn test_cases() -> std::vec::Vec<(usize, $t, $t)> {
                     std::vec![$(($round, $mult, $mask)),*]
                 }
@@ -708,22 +708,22 @@ mod tests {
     macro_rules! impl_undilation_test_data {
         ($t:ty, $d:literal, $undil_max:literal, $undil_shift:literal, $num_rounds:literal, $(($round:literal, $mult:literal, $mask:literal)),*) => {
             impl UndilationTestData<$t, $d> {
-                #[inline]
+                #[inline(always)]
                 fn fixed_undilated_max() -> $t {
                     $undil_max
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn undilate_shift() -> usize {
                     $undil_shift
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn num_rounds() -> usize {
                     $num_rounds
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn test_cases() -> std::vec::Vec<(usize, $t, $t)> {
                     std::vec![$(($round, $mult, $mask)),*]
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,14 +361,14 @@ where
     ///
     /// # Panics
     /// * Panics if parameter 'dilated' contains bits outside expected positions indicated by [DilationMethod::DILATED_MASK]
-    #[inline]
+    #[inline(always)]
     pub fn new(dilated: DM::Dilated) -> Self {
         debug_assert!(dilated.bit_and(DM::DILATED_MAX.bit_not()) == DM::Dilated::zero(), "Parameter 'dilated' contains bits outside expected positions indicated by DilationMethod::DILATED_MAX");
         Self(dilated)
     }
 
     /// Access dilated value
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn value(&self) -> DM::Dilated {
         self.0
@@ -389,7 +389,7 @@ where
     /// ```
     ///
     /// See also [DilationMethod::undilate()]
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn undilate(self) -> DM::Undilated {
         DM::undilate(self)
@@ -409,7 +409,7 @@ where
     /// assert_eq!(127u8.dilate_expand::<3>().add_one().undilate(), 128);
     /// assert_eq!(255u8.dilate_expand::<3>().add_one().undilate(), 0);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn add_one(self) -> Self {
         Self(
@@ -431,7 +431,7 @@ where
     /// assert_eq!(127u8.dilate_expand::<3>().sub_one().undilate(), 126);
     /// assert_eq!(255u8.dilate_expand::<3>().sub_one().undilate(), 254);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn sub_one(self) -> Self {
         Self(
@@ -465,7 +465,7 @@ where
     ///
     /// assert_eq!(dilated_a.add(dilated_b).undilate(), value_a + value_b);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn add(self, rhs: Self) -> Self {
         Self(
@@ -502,7 +502,7 @@ where
     ///
     /// assert_eq!(dilated_a.undilate(), value_a + value_b);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn add_assign(&mut self, rhs: Self) {
         *self = self.add(rhs);
     }
@@ -531,7 +531,7 @@ where
     ///
     /// assert_eq!(dilated_a.sub(dilated_b).undilate(), value_a - value_b);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[must_use]
     pub fn sub(self, rhs: Self) -> Self {
         Self(self.0.sub_wrapping(rhs.0).bit_and(DM::DILATED_MAX))
@@ -563,7 +563,7 @@ where
     ///
     /// assert_eq!(dilated_a.undilate(), value_a - value_b);
     /// ```
-    #[inline]
+    #[inline(always)]
     pub fn sub_assign(&mut self, rhs: Self) {
         *self = self.sub(rhs);
     }
@@ -587,7 +587,7 @@ mod std_impls {
         DM: DilationMethod,
         DM::Dilated: fmt::Display,
     {
-        #[inline]
+        #[inline(always)]
         #[must_use]
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "{}", self.value())
@@ -600,7 +600,7 @@ mod std_impls {
     {
         type Output = Self;
 
-        #[inline]
+        #[inline(always)]
         #[must_use]
         fn add(self, rhs: Self) -> Self::Output {
             self.add(rhs)
@@ -611,7 +611,7 @@ mod std_impls {
     where
         DM: DilationMethod,
     {
-        #[inline]
+        #[inline(always)]
         fn add_assign(&mut self, rhs: Self) {
             self.add_assign(rhs);
         }
@@ -623,7 +623,7 @@ mod std_impls {
     {
         type Output = Self;
 
-        #[inline]
+        #[inline(always)]
         #[must_use]
         fn sub(self, rhs: Self) -> Self::Output {
             self.sub(rhs)
@@ -634,7 +634,7 @@ mod std_impls {
     where
         DM: DilationMethod,
     {
-        #[inline]
+        #[inline(always)]
         fn sub_assign(&mut self, rhs: Self) {
             self.sub_assign(rhs);
         }
@@ -658,12 +658,12 @@ pub(crate) mod shared_test_data {
     macro_rules! impl_test_data {
         ($method_t:ty, $dil_max:expr, $con_max:expr) => {
             impl TestData<$method_t> {
-                #[inline]
+                #[inline(always)]
                 fn dilated_max() -> <$method_t as DilationMethod>::Dilated {
                     $dil_max
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn undilated_max() -> <$method_t as DilationMethod>::Undilated {
                     $con_max
                 }


### PR DESCRIPTION
Add first pass benchmarks.

These are currently just for internal benchmarking. I haven't yet found another dilation library to compare against.